### PR TITLE
使用 ueberzugpp 改善 fzf 对图片的预览功能

### DIFF
--- a/lib/file_preview.sh
+++ b/lib/file_preview.sh
@@ -1,12 +1,15 @@
 #! /usr/bin/env sh
 mime=$(file -bL --mime-type "$1")
 category=${mime%%/*}
+command -v ueberzugpp >/dev/null 2>&1 && [ -n "$UEBERZUGPP_SOCKET" ] && ub_avail="yes"
 if [ -d "$1" ]; then
+    [ "$ub_avail" = "yes" ] && bash $OMZ/lib/img_preview.sh remove
     exa -l --no-user --no-time --icons --no-permissions --no-filesize "$1" 2>/dev/null || ls --color=always "$1" 2>/dev/null || ls -G "$1"
 elif [ "$category" = text ]; then
+    [ "$ub_avail" = "yes" ] && bash $OMZ/lib/img_preview.sh remove
     (bat -p --color=always "$1" || cat "$1") 2>/dev/null | head -1000
 elif [ "$category" = image ]; then
-    command -v ueberzug 2&>/dev/null && bash $OMZ/lib/img_preview.sh "$1"|| img2txt "$1"
+    [ "$ub_avail" = "yes" ] && bash $OMZ/lib/img_preview.sh draw "$1"|| img2txt "$1"
 else 
     echo $1 is a $category file
     (bat -p --color=always "$1" || cat "$1") 2>/dev/null | head -1000

--- a/lib/img_preview.sh
+++ b/lib/img_preview.sh
@@ -1,44 +1,26 @@
 #!/usr/bin/env bash
 
 declare -r -x DEFAULT_PREVIEW_POSITION="right"
-declare -r -x UEBERZUG_FIFO="$(mktemp --dry-run --suffix "fzf-$$-ueberzug")"
 declare -r -x PREVIEW_ID="preview"
 
-function start_ueberzug {
-    mkfifo "${UEBERZUG_FIFO}"
-    <"${UEBERZUG_FIFO}" \
-        ueberzug layer --parser bash --silent &
-    3>"${UEBERZUG_FIFO}" \
-        exec
-}
-
-function finalise {
-    3>&- \
-        exec
-    &>/dev/null \
-        rm "${UEBERZUG_FIFO}"
-    &>/dev/null \
-        kill $(jobs -p)
-    killall ueberzug
-}
+source $OMZ/cache/cursor
+X=$(($COLUMNS / 2 + 2))
+Y=$((row + 2))
+if [ $Y -gt $((LINES - 11)) ]; then
+    Y=$((LINES - 11))
+fi
 
 function draw_preview {
-    source $OMZ/cache/cursor
-    X=$(($COLUMNS / 2 + 2))
-    Y=$((row + 2))
-    if [ $Y -gt $((LINES - 11)) ]; then
-        Y=$((LINES - 11))
-    fi
-
-    >"${UEBERZUG_FIFO}" declare -A -p cmd=( \
-        [action]=add [identifier]="${PREVIEW_ID}" \
-        [x]="${X}" [y]="${Y}" \
-        [width]="$(($COLUMNS / 2 - 2))" [height]="10" \
-        [scaler]=forced_cover [scaling_position_x]=0.5 [scaling_position_y]=0.5 \
-        [path]="${@}")
+    ueberzugpp cmd -s $UEBERZUGPP_SOCKET -i $PREVIEW_ID -a add \
+        -x $X -y $Y --max-width $(($COLUMNS / 2 - 2)) --max-height 10 \
+        -f ${@}
 }
 
-trap finalise EXIT
-start_ueberzug
-draw_preview $*
-sleep 999999
+function remove_preview {
+    ueberzugpp cmd -s $UEBERZUGPP_SOCKET -i $PREVIEW_ID -a remove
+}
+
+case "$1" in
+	draw) shift; draw_preview $* ;;
+	remove) remove_preview ;;
+esac

--- a/omz.zsh
+++ b/omz.zsh
@@ -1,4 +1,5 @@
 export OMZ=$(cd $(dirname $0);pwd)
+export UEBERZUGPP_PID_FILE=$OMZ/cache/ubpidfile
 source $OMZ/config/omz.zsh
 source $OMZ/config/git.zsh
 source $OMZ/config/fzf.zsh


### PR DESCRIPTION
# 使用 ueberzugpp 重构图片预览功能

## 问题描述

原版图片预览功能存在以下问题：

1. **进程管理问题**：每次预览图片都会创建新的 ueberzug 进程，导致：
   - 快速切换时产生大量僵尸进程
   - 图片残留无法正常清除
   - 使用 `sleep 9999` 的笨拙方法来维持进程

2. **技术过时**：使用已过时的 ueberzug，而非其现代化替代品 [ueberzugpp](https://github.com/jstkdng/ueberzugpp)
   - 使用的是老一套 api，不能兼容新版本 ueberzug
   - 与其他的应用如 [yazi](https://github.com/sxyazi/yazi) 等产生冲突

## 解决方案

### 核心改进
- ✅ **升级依赖**：将 ueberzug 替换为 ueberzugpp
- ✅ **进程管理重构**：在 fzf 启动/关闭时统一管理 ueberzugpp 进程，一次预览只开一个进程
- ✅ **预览体验优化**：实现文本/图片预览的无缝切换，并规避了图片残留问题

### 技术细节

#### 1. 进程生命周期管理
```bash
# fzf-tab 插件中新增进程管理函数
-ftb-start-ueberzugpp()   # fzf 启动时创建 ueberzugpp 实例
-ftb-stop-ueberzugpp()    # fzf 退出时安全关闭
```

#### 2. 图片预览脚本重构
- `img_preview.sh` 支持 `draw` 和 `remove` 命令
- 使用 socket 通信替代进程频繁创建
- 摒弃了传统使用 sleep 9999 延后进程退出的方法

#### 3. 文件预览逻辑改变
```bash
# 在显示文本/目录时移除图片预览
[ "$ub_avail" = "yes" ] && bash $OMZ/lib/img_preview.sh remove
```

## 测试验证

- ✅图片预览正常显示
- ✅ 快速切换无残留图片
- ✅ 文本/图片预览切换流畅
- ✅ 进程无泄漏，退出后完全清理
- ✅ 向后兼容（无 ueberzugpp 时回退到 img2txt）

## 相关文件修改
- `lib/file_preview.sh` - 预览逻辑优化
- `lib/img_preview.sh` - 核心预览功能重构  
- `omz.zsh` - 环境变量配置
- `plugins/fzf-tab/fzf-tab.zsh` - 集成进程管理